### PR TITLE
refactor: make YARAPA rule policy static

### DIFF
--- a/packages/eslint-config-yarapa/src/configs/base.ts
+++ b/packages/eslint-config-yarapa/src/configs/base.ts
@@ -3,7 +3,6 @@ import type { Linter } from "eslint";
 import commentsPlugin, {
   configs as commentsConfigs,
 } from "@eslint-community/eslint-plugin-eslint-comments";
-import js from "@eslint/js";
 import promisePlugin from "eslint-plugin-promise";
 import { configs as regexpConfigs } from "eslint-plugin-regexp";
 import unusedImportsPlugin from "eslint-plugin-unused-imports";
@@ -11,10 +10,72 @@ import unusedImportsPlugin from "eslint-plugin-unused-imports";
 import { asFlatPlugin } from "./internal/eslintCompat.js";
 import { required } from "./internal/required.js";
 
-const jsRecommendedRules = required(
-  js.configs.recommended.rules,
-  "@eslint/js.configs.recommended.rules",
-);
+const jsRecommendedRules: Linter.RulesRecord = {
+  "constructor-super": "error",
+  "for-direction": "error",
+  "getter-return": "error",
+  "no-async-promise-executor": "error",
+  "no-case-declarations": "error",
+  "no-class-assign": "error",
+  "no-compare-neg-zero": "error",
+  "no-cond-assign": "error",
+  "no-const-assign": "error",
+  "no-constant-binary-expression": "error",
+  "no-constant-condition": "error",
+  "no-control-regex": "error",
+  "no-debugger": "error",
+  "no-delete-var": "error",
+  "no-dupe-args": "error",
+  "no-dupe-class-members": "error",
+  "no-dupe-else-if": "error",
+  "no-dupe-keys": "error",
+  "no-duplicate-case": "error",
+  "no-empty": "error",
+  "no-empty-character-class": "error",
+  "no-empty-pattern": "error",
+  "no-empty-static-block": "error",
+  "no-ex-assign": "error",
+  "no-extra-boolean-cast": "error",
+  "no-fallthrough": "error",
+  "no-func-assign": "error",
+  "no-global-assign": "error",
+  "no-import-assign": "error",
+  "no-invalid-regexp": "error",
+  "no-irregular-whitespace": "error",
+  "no-loss-of-precision": "error",
+  "no-misleading-character-class": "error",
+  "no-new-native-nonconstructor": "error",
+  "no-nonoctal-decimal-escape": "error",
+  "no-obj-calls": "error",
+  "no-octal": "error",
+  "no-prototype-builtins": "error",
+  "no-redeclare": "error",
+  "no-regex-spaces": "error",
+  "no-self-assign": "error",
+  "no-setter-return": "error",
+  "no-shadow-restricted-names": "error",
+  "no-sparse-arrays": "error",
+  "no-this-before-super": "error",
+  "no-unassigned-vars": "error",
+  "no-undef": "error",
+  "no-unexpected-multiline": "error",
+  "no-unreachable": "error",
+  "no-unsafe-finally": "error",
+  "no-unsafe-negation": "error",
+  "no-unsafe-optional-chaining": "error",
+  "no-unused-labels": "error",
+  "no-unused-private-class-members": "error",
+  "no-unused-vars": "error",
+  "no-useless-assignment": "error",
+  "no-useless-backreference": "error",
+  "no-useless-catch": "error",
+  "no-useless-escape": "error",
+  "no-with": "error",
+  "preserve-caught-error": "error",
+  "require-yield": "error",
+  "use-isnan": "error",
+  "valid-typeof": "error",
+};
 
 const promiseRecommended = required(
   promisePlugin.configs["flat/recommended"],
@@ -37,7 +98,7 @@ const regexpRecommended = regexpConfigs["flat/recommended"];
 export const base: Linter.Config[] = [
   {
     name: "yarapa/base/eslint-recommended",
-    rules: { ...jsRecommendedRules },
+    rules: jsRecommendedRules,
   },
   {
     name: "yarapa/base/eslint-comments-recommended",

--- a/packages/eslint-config-yarapa/test/static-rule-policy.test.ts
+++ b/packages/eslint-config-yarapa/test/static-rule-policy.test.ts
@@ -1,6 +1,9 @@
+import type eslintJs from "@eslint/js";
 import type { Linter } from "eslint";
 
 import { afterEach, describe, expect, it, vi } from "vitest";
+
+const ESLINT_JS_MODULE = "@eslint/js";
 
 /**
  * Resolve the final configured value for one rule across a config array.
@@ -26,15 +29,15 @@ function findRule(
 }
 
 afterEach(() => {
-  vi.doUnmock("@eslint/js");
+  vi.doUnmock(ESLINT_JS_MODULE);
   vi.resetModules();
 });
 
 describe("static rule policy", () => {
   it("does not inherit newly exported upstream rules implicitly", async () => {
     vi.resetModules();
-    vi.doMock("@eslint/js", async importOriginal => {
-      const original = await importOriginal<typeof import("@eslint/js")>();
+    vi.doMock(ESLINT_JS_MODULE, async importOriginal => {
+      const original = await importOriginal<typeof eslintJs>();
       const recommended = original.configs.recommended;
 
       return {

--- a/packages/eslint-config-yarapa/test/static-rule-policy.test.ts
+++ b/packages/eslint-config-yarapa/test/static-rule-policy.test.ts
@@ -35,13 +35,13 @@ describe("static rule policy", () => {
     vi.resetModules();
     vi.doMock("@eslint/js", async importOriginal => {
       const original = await importOriginal<typeof import("@eslint/js")>();
-      const recommended = original.default.configs.recommended;
+      const recommended = original.configs.recommended;
 
       return {
         default: {
-          ...original.default,
+          ...original,
           configs: {
-            ...original.default.configs,
+            ...original.configs,
             recommended: {
               ...recommended,
               rules: {

--- a/packages/eslint-config-yarapa/test/static-rule-policy.test.ts
+++ b/packages/eslint-config-yarapa/test/static-rule-policy.test.ts
@@ -1,0 +1,61 @@
+import type { Linter } from "eslint";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Resolve the final configured value for one rule across a config array.
+ * @param config Flat Config array.
+ * @param ruleName Rule name to resolve.
+ * @returns The final configured rule entry.
+ */
+function findRule(
+  config: Linter.Config[],
+  ruleName: string,
+): Linter.RuleEntry | undefined {
+  let resolved: Linter.RuleEntry | undefined;
+
+  for (const entry of config) {
+    const rule = Reflect.get(entry.rules ?? {}, ruleName) as
+      | Linter.RuleEntry
+      | undefined;
+
+    if (rule !== undefined) resolved = rule;
+  }
+
+  return resolved;
+}
+
+afterEach(() => {
+  vi.doUnmock("@eslint/js");
+  vi.resetModules();
+});
+
+describe("static rule policy", () => {
+  it("does not inherit newly exported upstream rules implicitly", async () => {
+    vi.resetModules();
+    vi.doMock("@eslint/js", async importOriginal => {
+      const original = await importOriginal<typeof import("@eslint/js")>();
+      const recommended = original.default.configs.recommended;
+
+      return {
+        default: {
+          ...original.default,
+          configs: {
+            ...original.default.configs,
+            recommended: {
+              ...recommended,
+              rules: {
+                ...recommended.rules,
+                "no-alert": "error",
+              },
+            },
+          },
+        },
+      };
+    });
+
+    const { base } = await import("../src/configs/base.js");
+
+    expect(findRule(base, "no-alert")).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Implements #29.

Scope:
- replace consumer-visible upstream rule inheritance with static, reviewable YARAPA rule maps
- preserve upstream parser/plugin/settings wiring where it does not determine consumer rule policy
- keep recommended-first eligibility while preventing plugin upgrades from silently expanding behavior
- preserve the static SonarJS exception and canonical owner decisions
- add behavior evidence that a newly exported upstream rule is not adopted without a YARAPA source change

This PR starts in Draft with a RED test. No deploy, publish, tag, release, paid tooling, or mutation testing is included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated the base linting configuration to use an explicit, stable set of recommended JavaScript rules.
  * Linting behavior no longer depends on dynamically resolved upstream recommendations.

* **Tests**
  * Added regression coverage to ensure the base linting configuration does not unintentionally inherit newly introduced upstream recommended rules.
  * Added validation for resolving the effective setting of a rule across configuration entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->