### PR TITLE
feat: modernize Airbnb patterns into YARAPA handwriting

### DIFF
--- a/packages/eslint-config-yarapa/scripts/verify-tarball.mts
+++ b/packages/eslint-config-yarapa/scripts/verify-tarball.mts
@@ -34,7 +34,9 @@ function run(command: string, args: string[], cwd: string): void {
     stdio: "inherit",
   });
 
-  if (result.error) throw result.error;
+  if (result.error) {
+    throw result.error;
+  }
   if (result.status !== 0) {
     throw new Error(
       `${command} ${args.join(" ")} failed with ${result.status}`,
@@ -57,7 +59,9 @@ try {
   run(pnpm, ["pack", "--pack-destination", packDir], packageRoot);
 
   const tarballName = readdirSync(packDir).find(name => name.endsWith(".tgz"));
-  if (!tarballName) throw new Error("pnpm pack did not produce a tarball");
+  if (!tarballName) {
+    throw new Error("pnpm pack did not produce a tarball");
+  }
   const tarball = resolve(packDir, tarballName);
 
   run(pnpm, ["exec", "attw", tarball, "--profile", "esm-only"], packageRoot);

--- a/packages/eslint-config-yarapa/src/configs/base.ts
+++ b/packages/eslint-config-yarapa/src/configs/base.ts
@@ -77,6 +77,20 @@ const jsRecommendedRules: Linter.RulesRecord = {
   "valid-typeof": "error",
 };
 
+const modernJavaScriptRules: Linter.RulesRecord = {
+  "arrow-body-style": [
+    "error",
+    "as-needed",
+    { requireReturnForObjectLiteral: false },
+  ],
+  eqeqeq: ["error", "always"],
+  "no-var": "error",
+  "object-shorthand": ["error", "always"],
+  "prefer-const": "error",
+  "prefer-object-spread": "error",
+  "prefer-template": "error",
+};
+
 const promiseRecommended = required(
   promisePlugin.configs["flat/recommended"],
   "eslint-plugin-promise.configs.flat/recommended",
@@ -91,14 +105,18 @@ const regexpRecommended = regexpConfigs["flat/recommended"];
 
 /**
  * Universally relevant, non-type-aware JavaScript baseline: ESLint core
- * recommended coverage, Promise and asynchronous control-flow checks,
- * regular-expression checks, unused-import controls, and auditable ESLint
- * suppression comments.
+ * recommended coverage, deliberate modern JavaScript handwriting, Promise
+ * and asynchronous control-flow checks, regular-expression checks,
+ * unused-import controls, and auditable ESLint suppression comments.
  */
 export const base: Linter.Config[] = [
   {
     name: "yarapa/base/eslint-recommended",
     rules: jsRecommendedRules,
+  },
+  {
+    name: "yarapa/base/modern-js-handwriting",
+    rules: modernJavaScriptRules,
   },
   {
     name: "yarapa/base/eslint-comments-recommended",

--- a/packages/eslint-config-yarapa/src/configs/base.ts
+++ b/packages/eslint-config-yarapa/src/configs/base.ts
@@ -83,12 +83,21 @@ const modernJavaScriptRules: Linter.RulesRecord = {
     "as-needed",
     { requireReturnForObjectLiteral: false },
   ],
+  curly: ["error", "all"],
+  "default-param-last": "error",
+  "dot-notation": "error",
   eqeqeq: ["error", "always"],
+  "no-array-constructor": "error",
+  "no-object-constructor": "error",
   "no-var": "error",
   "object-shorthand": ["error", "always"],
   "prefer-const": "error",
+  "prefer-object-has-own": "error",
   "prefer-object-spread": "error",
+  "prefer-rest-params": "error",
+  "prefer-spread": "error",
   "prefer-template": "error",
+  radix: "error",
 };
 
 const promiseRecommended = required(

--- a/packages/eslint-config-yarapa/src/configs/internal/required.ts
+++ b/packages/eslint-config-yarapa/src/configs/internal/required.ts
@@ -8,7 +8,7 @@ export function required<T>(
   value: null | T | undefined,
   label: string,
 ): T {
-  if (value == null) {
+  if (value === null || value === undefined) {
     throw new Error(`Missing required upstream config: ${label}`);
   }
 

--- a/packages/eslint-config-yarapa/src/configs/recommended.ts
+++ b/packages/eslint-config-yarapa/src/configs/recommended.ts
@@ -12,6 +12,16 @@ import { stylistic } from "./stylistic.js";
 import { typeChecked } from "./typeChecked.js";
 import { typescript } from "./typescript.js";
 
+const modernJavaScriptOwnership: Linter.Config = {
+  name: "yarapa/canonical-ownership/modern-js",
+  rules: {
+    "sonarjs/arguments-usage": "off",
+    "sonarjs/array-constructor": "off",
+    "sonarjs/arrow-function-convention": "off",
+    "sonarjs/prefer-default-last": "off",
+  },
+};
+
 /**
  * The aggregate Banking Baseline. Applies every universally relevant control:
  * ESLint core recommended, TypeScript recommended and type-aware recommended
@@ -35,6 +45,7 @@ export const recommended: Linter.Config[] = [
   ...typeChecked,
   ...importResolution,
   ...sonarjsAllRules,
+  modernJavaScriptOwnership,
   ...security,
   ...jsdoc,
   ...json,

--- a/packages/eslint-config-yarapa/src/configs/typeChecked.ts
+++ b/packages/eslint-config-yarapa/src/configs/typeChecked.ts
@@ -25,11 +25,13 @@ export const typeChecked: Linter.Config[] = asFlatConfigArray(
     },
     name: "yarapa/type-checked/recommended",
     rules: {
+      "dot-notation": "off",
       "@typescript-eslint/await-thenable": "error",
       "@typescript-eslint/consistent-type-exports": [
         "error",
         { fixMixedExportsWithInlineTypeSpecifier: false },
       ],
+      "@typescript-eslint/dot-notation": "error",
       "@typescript-eslint/no-floating-promises": "error",
       "@typescript-eslint/no-misused-promises": "error",
       "@typescript-eslint/no-unnecessary-type-assertion": "error",

--- a/packages/eslint-config-yarapa/src/configs/typeChecked.ts
+++ b/packages/eslint-config-yarapa/src/configs/typeChecked.ts
@@ -25,7 +25,6 @@ export const typeChecked: Linter.Config[] = asFlatConfigArray(
     },
     name: "yarapa/type-checked/recommended",
     rules: {
-      "dot-notation": "off",
       "@typescript-eslint/await-thenable": "error",
       "@typescript-eslint/consistent-type-exports": [
         "error",
@@ -37,6 +36,7 @@ export const typeChecked: Linter.Config[] = asFlatConfigArray(
       "@typescript-eslint/no-unnecessary-type-assertion": "error",
       "@typescript-eslint/only-throw-error": "error",
       "@typescript-eslint/unbound-method": "error",
+      "dot-notation": "off",
     },
   }),
 );

--- a/packages/eslint-config-yarapa/src/configs/typescript.ts
+++ b/packages/eslint-config-yarapa/src/configs/typescript.ts
@@ -23,6 +23,8 @@ export const typescript: Linter.Config[] = asFlatConfigArray(
       files: ["**/*.ts", "**/*.tsx", "**/*.mts", "**/*.cts"],
       name: "yarapa/typescript/recommended",
       rules: {
+        "default-param-last": "off",
+        "no-array-constructor": "off",
         "@typescript-eslint/ban-ts-comment": [
           "error",
           {
@@ -37,6 +39,8 @@ export const typescript: Linter.Config[] = asFlatConfigArray(
           "error",
           { fixStyle: "separate-type-imports", prefer: "type-imports" },
         ],
+        "@typescript-eslint/default-param-last": "error",
+        "@typescript-eslint/no-array-constructor": "error",
         "@typescript-eslint/no-import-type-side-effects": "error",
         "@typescript-eslint/no-non-null-assertion": "error",
         // `unused-imports/no-unused-vars` (from `base`) is the active

--- a/packages/eslint-config-yarapa/src/configs/typescript.ts
+++ b/packages/eslint-config-yarapa/src/configs/typescript.ts
@@ -23,8 +23,6 @@ export const typescript: Linter.Config[] = asFlatConfigArray(
       files: ["**/*.ts", "**/*.tsx", "**/*.mts", "**/*.cts"],
       name: "yarapa/typescript/recommended",
       rules: {
-        "default-param-last": "off",
-        "no-array-constructor": "off",
         "@typescript-eslint/ban-ts-comment": [
           "error",
           {
@@ -49,6 +47,8 @@ export const typescript: Linter.Config[] = asFlatConfigArray(
         // typescript-eslint rule must stay off to avoid duplicate/
         // conflicting reports on the same bindings.
         "@typescript-eslint/no-unused-vars": "off",
+        "default-param-last": "off",
+        "no-array-constructor": "off",
       },
     },
     {

--- a/packages/eslint-config-yarapa/test/autofix.test.ts
+++ b/packages/eslint-config-yarapa/test/autofix.test.ts
@@ -84,4 +84,26 @@ describe("autofix safety and idempotence", () => {
       output.indexOf("from \"z\""),
     );
   });
+
+  it("normalizes template strings and object shorthand once", async () => {
+    const output = await fixTwice(
+      yarapa,
+      "export function greet(name) { const value = \"Hello \" + name; return { value: value }; }\n",
+      "fixtures/autofix/modern-js.js",
+    );
+
+    expect(output).toBe(
+      "export function greet(name) { const value = `Hello ${name}`; return { value }; }\n",
+    );
+  });
+
+  it("normalizes expression arrows to implicit returns once", async () => {
+    const output = await fixTwice(
+      yarapa,
+      "export const double = value => { return value * 2; };\n",
+      "fixtures/autofix/implicit-arrow.js",
+    );
+
+    expect(output).toBe("export const double = value => value * 2;\n");
+  });
 });

--- a/packages/eslint-config-yarapa/test/autofix.test.ts
+++ b/packages/eslint-config-yarapa/test/autofix.test.ts
@@ -88,12 +88,12 @@ describe("autofix safety and idempotence", () => {
   it("normalizes template strings and object shorthand once", async () => {
     const output = await fixTwice(
       yarapa,
-      "export function greet(name) { const value = \"Hello \" + name; return { value: value }; }\n",
+      "export const greet = name => { const value = \"Hello \" + name; return { value: value }; };\n",
       "fixtures/autofix/modern-js.js",
     );
 
     expect(output).toBe(
-      "export function greet(name) { const value = `Hello ${name}`; return { value }; }\n",
+      "export const greet = name => { const value = `Hello ${name}`; return { value }; };\n",
     );
   });
 

--- a/packages/eslint-config-yarapa/test/behavior.test.ts
+++ b/packages/eslint-config-yarapa/test/behavior.test.ts
@@ -82,4 +82,62 @@ describe("shared YARAPA behavior", () => {
       "eqeqeq",
     );
   });
+
+  it("prefers literal constructors and dot property access", async () => {
+    const source = [
+      "export const build = value => {",
+      "  const object = new Object();",
+      "  const items = new Array(value, value);",
+      "  object[\"value\"] = items[0];",
+      "  return object;",
+      "};",
+      "",
+    ].join("\n");
+    const [result] = await eslint.lintText(source, {
+      filePath: javascriptFixture,
+    });
+    const lintResult = required(result, "literal syntax lint result");
+    const ruleIds = lintResult.messages.map(message => message.ruleId);
+
+    expect(ruleIds).toContain("no-object-constructor");
+    expect(ruleIds).toContain("no-array-constructor");
+    expect(ruleIds).toContain("dot-notation");
+  });
+
+  it("prefers rest/spread and default parameters last", async () => {
+    const source = [
+      "export const call = (fallback = 0, action, args) =>",
+      "  action.apply(undefined, args) ?? fallback;",
+      "export function collect() { return Array.from(arguments); }",
+      "",
+    ].join("\n");
+    const [result] = await eslint.lintText(source, {
+      filePath: javascriptFixture,
+    });
+    const lintResult = required(result, "modern function lint result");
+    const ruleIds = lintResult.messages.map(message => message.ruleId);
+
+    expect(ruleIds).toContain("default-param-last");
+    expect(ruleIds).toContain("prefer-spread");
+    expect(ruleIds).toContain("prefer-rest-params");
+  });
+
+  it("requires braces, Object.hasOwn, and explicit parseInt radix", async () => {
+    const source = [
+      "export const parse = (object, key, value) => {",
+      "  if (object) return Object.prototype.hasOwnProperty.call(object, key);",
+      "  return parseInt(value);",
+      "};",
+      "",
+    ].join("\n");
+    const [result] = await eslint.lintText(source, {
+      filePath: javascriptFixture,
+    });
+    const lintResult = required(result, "modern builtins lint result");
+    const ruleIds = lintResult.messages.map(message => message.ruleId);
+
+    expect(ruleIds).toContain("curly");
+    expect(ruleIds).toContain("prefer-object-has-own");
+    expect(ruleIds).toContain("radix");
+  });
 });

--- a/packages/eslint-config-yarapa/test/behavior.test.ts
+++ b/packages/eslint-config-yarapa/test/behavior.test.ts
@@ -22,6 +22,10 @@ function messageSummary(result: ESLint.LintResult): object[] {
 
 describe("shared YARAPA behavior", () => {
   const eslint = eslintForConfigs(yarapa);
+  const javascriptFixture = resolve(
+    packageRoot,
+    "fixtures/valid/base/case.js",
+  );
   const projectRoot = resolve(packageRoot, "fixtures/projects/typed");
 
   it("accepts a typed project source file", async () => {
@@ -46,12 +50,36 @@ describe("shared YARAPA behavior", () => {
 
   it("rejects unused JavaScript variables", async () => {
     const [result] = await eslint.lintText("const unused = 1;\n", {
-      filePath: resolve(packageRoot, "fixtures/valid/base/case.js"),
+      filePath: javascriptFixture,
     });
     const lintResult = required(result, "unused variable lint result");
 
     expect(lintResult.messages.map(message => message.ruleId)).toContain(
       "unused-imports/no-unused-vars",
+    );
+  });
+
+  it("rejects var in shared JavaScript handwriting", async () => {
+    const [result] = await eslint.lintText(
+      "export function increment(value) { var next = value + 1; return next; }\n",
+      { filePath: javascriptFixture },
+    );
+    const lintResult = required(result, "var lint result");
+
+    expect(lintResult.messages.map(message => message.ruleId)).toContain(
+      "no-var",
+    );
+  });
+
+  it("requires strict equality in shared JavaScript handwriting", async () => {
+    const [result] = await eslint.lintText(
+      "export const equivalent = (left, right) => left == right;\n",
+      { filePath: javascriptFixture },
+    );
+    const lintResult = required(result, "equality lint result");
+
+    expect(lintResult.messages.map(message => message.ruleId)).toContain(
+      "eqeqeq",
     );
   });
 });

--- a/packages/eslint-config-yarapa/test/profiles.test.ts
+++ b/packages/eslint-config-yarapa/test/profiles.test.ts
@@ -21,7 +21,9 @@ function findRule(
       | Linter.RuleEntry
       | undefined;
 
-    if (rule !== undefined) resolved = rule;
+    if (rule !== undefined) {
+      resolved = rule;
+    }
   }
 
   return resolved;
@@ -62,21 +64,68 @@ describe("semantic profiles", () => {
     for (const ruleName of [
       "@stylistic/semi",
       "@typescript-eslint/consistent-type-imports",
+      "@typescript-eslint/default-param-last",
+      "@typescript-eslint/dot-notation",
+      "@typescript-eslint/no-array-constructor",
       "@typescript-eslint/no-floating-promises",
       "arrow-body-style",
+      "curly",
       "eqeqeq",
       "import-x/no-duplicates",
+      "no-object-constructor",
       "no-var",
       "object-shorthand",
       "prefer-const",
+      "prefer-object-has-own",
       "prefer-object-spread",
+      "prefer-rest-params",
+      "prefer-spread",
       "prefer-template",
+      "radix",
     ]) {
       const resolved = profiles.map(profile => findRule(profile, ruleName));
       const [first, ...rest] = resolved;
 
       expect(first).toBeDefined();
-      for (const value of rest) expect(value).toStrictEqual(first);
+      for (const value of rest) {
+        expect(value).toStrictEqual(first);
+      }
+    }
+  });
+
+  it("keeps modern JavaScript concerns on canonical owners", async () => {
+    const profiles = await Promise.all(
+      PROFILE_NAMES.map(profileName => loadProfile(profileName)),
+    );
+
+    for (const profile of profiles) {
+      expect(findRule(profile, "sonarjs/arguments-usage")).toBe("off");
+      expect(findRule(profile, "sonarjs/array-constructor")).toBe("off");
+      expect(findRule(profile, "sonarjs/arrow-function-convention")).toBe(
+        "off",
+      );
+      expect(findRule(profile, "sonarjs/prefer-default-last")).toBe("off");
+    }
+  });
+
+  it("uses @stylistic instead of deprecated core formatting rules", async () => {
+    const profiles = await Promise.all(
+      PROFILE_NAMES.map(profileName => loadProfile(profileName)),
+    );
+
+    for (const profile of profiles) {
+      for (const ruleName of [
+        "arrow-parens",
+        "brace-style",
+        "comma-dangle",
+        "indent",
+        "max-len",
+        "quotes",
+        "semi",
+      ]) {
+        expect(findRule(profile, ruleName)).toBeUndefined();
+        expect(findRule(profile, `@stylistic/${ruleName}`)).toBeDefined();
+      }
     }
   });
 });

--- a/packages/eslint-config-yarapa/test/profiles.test.ts
+++ b/packages/eslint-config-yarapa/test/profiles.test.ts
@@ -63,7 +63,14 @@ describe("semantic profiles", () => {
       "@stylistic/semi",
       "@typescript-eslint/consistent-type-imports",
       "@typescript-eslint/no-floating-promises",
+      "arrow-body-style",
+      "eqeqeq",
       "import-x/no-duplicates",
+      "no-var",
+      "object-shorthand",
+      "prefer-const",
+      "prefer-object-spread",
+      "prefer-template",
     ]) {
       const resolved = profiles.map(profile => findRule(profile, ruleName));
       const [first, ...rest] = resolved;

--- a/packages/eslint-config-yarapa/test/static-rule-policy.test.ts
+++ b/packages/eslint-config-yarapa/test/static-rule-policy.test.ts
@@ -22,7 +22,9 @@ function findRule(
       | Linter.RuleEntry
       | undefined;
 
-    if (rule !== undefined) resolved = rule;
+    if (rule !== undefined) {
+      resolved = rule;
+    }
   }
 
   return resolved;


### PR DESCRIPTION
Closes #24.

## Goal

Modernize durable Airbnb JavaScript Style Guide conventions into one shared YARAPA handwriting using maintained ESLint 10 / Flat Config rule owners. Airbnb is a design reference only; YARAPA remains final authority for severity/options.

## Hard boundaries

- no `eslint-config-airbnb` dependency, extends, composition, or compatibility layer
- no `/airbnb` preset or Airbnb-specific runtime API
- no generated compliance inventory or style-guide DSL
- no deploy/release work
- formatting remains owned by `@stylistic`
- TypeScript extension rules replace weaker core rules where they are the better semantic owner

## Section-by-section audit

- **Types — TS-REPLACE:** TypeScript compiler/typescript-eslint own type-era semantics; no Babel-era runtime policy copied.
- **References — KEEP:** `no-var`, `prefer-const`.
- **Objects — KEEP/MODERNIZE:** `no-object-constructor`, `object-shorthand`, `prefer-object-spread`; modernize prototype ownership checks to `prefer-object-has-own`; quote/spacing concerns remain `@stylistic`.
- **Arrays — KEEP + TS-REPLACE:** core `no-array-constructor` for JavaScript, `@typescript-eslint/no-array-constructor` for TypeScript.
- **Destructuring — KEEP:** existing SonarJS destructuring coverage remains complementary; do not add a second overlapping generic sorter/policy in this PR.
- **Strings — KEEP/MODERNIZE:** `prefer-template`; quote/template spacing remains `@stylistic`.
- **Functions — KEEP + TS-REPLACE:** `default-param-last`, `prefer-rest-params`, `prefer-spread`; TypeScript uses `@typescript-eslint/default-param-last`.
- **Arrow Functions — KEEP/MODERNIZE:** `arrow-body-style`; parens/spacing remain `@stylistic`; overlapping `sonarjs/arrow-function-convention` is disabled.
- **Classes & Constructors — TS-REPLACE:** TypeScript-specific constructor/class choices remain owned by typescript-eslint and are completed under #25 rather than duplicating JS-era rules here.
- **Modules — TS-REPLACE/MODERNIZE:** import correctness/order stays with `import-x`, typescript-eslint, and the single ordering owner; detailed module policy remains #26.
- **Iterators & Generators — OBSOLETE:** do not copy Airbnb's historical bundle-size-driven blanket `for...of` restriction into the Node 24 / modern-framework support contract.
- **Properties — KEEP + TS-REPLACE:** core `dot-notation` for JavaScript, `@typescript-eslint/dot-notation` for TypeScript.
- **Variables — KEEP:** `no-var`/`prefer-const`; no extra variable-style taxonomy added.
- **Hoisting — TS-REPLACE:** TypeScript-aware ownership is preferred over a blanket legacy JS rule; deeper TS policy remains #25.
- **Comparison Operators & Equality — KEEP:** `eqeqeq` at error severity.
- **Blocks — KEEP:** `curly` requires braces consistently.
- **Control Statements — YARAPA-STRICTER:** correctness/complexity stays under existing core/SonarJS ownership; do not copy blanket stylistic bans that encourage unnatural rewrites. #27/#35 complete those dimensions.
- **Comments — MODERNIZE:** formatting stays with `@stylistic`; suppression discipline stays with `eslint-comments` and #35.
- **Whitespace — MODERNIZE:** maintained `@stylistic` owner only.
- **Commas — MODERNIZE:** maintained `@stylistic` owner only.
- **Semicolons — YARAPA-STRICTER/MODERNIZE:** YARAPA keeps semicolons at error severity through `@stylistic`.
- **Type Casting & Coercion — KEEP:** explicit `radix`; TypeScript-specific coercion/type safety stays under #25/#27.
- **Naming Conventions — TS-REPLACE:** canonical naming work belongs to `@typescript-eslint/naming-convention` audit in #35; no duplicate legacy naming layer here.
- **Accessors — KEEP:** language correctness stays with existing maintained core/SonarJS rules; no bespoke accessor convention added.
- **Events — FRAMEWORK-DELTA:** framework/event semantics belong to React/Next adapters only when technically required.
- **jQuery — OBSOLETE:** no jQuery-specific policy in the v1 support contract.
- **ECMAScript 5 Compatibility — OBSOLETE:** no ES5/Babel-polyfill assumptions for the declared modern runtime contract.
- **ECMAScript 6+ Styles — KEEP:** modern syntax preferences above are shared baseline policy.
- **Standard Library — MODERNIZE:** `Object.hasOwn` is preferred over legacy prototype-call patterns.
- **Testing — FRAMEWORK-DELTA:** runner/library semantics are independent and handled under #32; generic handwriting remains shared.
- **Performance — OBSOLETE:** do not turn historical bundle/transpilation guidance into modern lint restrictions without current evidence.

## Canonical ownership decisions

ESLint core is the primary owner for language-level JavaScript conventions. TypeScript extension rules replace core equivalents when they add TypeScript semantics. `@stylistic` owns formatting. SonarJS remains broad complementary coverage, but exact duplicates introduced by this work are disabled:

- `sonarjs/array-constructor` → `no-array-constructor` / `@typescript-eslint/no-array-constructor`
- `sonarjs/arguments-usage` → `prefer-rest-params`
- `sonarjs/arrow-function-convention` → `arrow-body-style` + `@stylistic/arrow-parens`
- `sonarjs/prefer-default-last` → `default-param-last` / `@typescript-eslint/default-param-last`

## Verification

- RED behavior tests were observed before each production rule batch
- real ESLint behavior tests cover invalid JavaScript patterns
- autofix tests cover template strings, object shorthand, and implicit arrow returns
- autofix is run twice to prove idempotence
- profile tests require shared rule invariance across `/next`, `/nest`, `/react`
- profile tests verify deprecated core formatting rules are not the active owner when `@stylistic` equivalents exist
- repository dogfoods the built config
- packed consumer and compatibility jobs remain required through aggregate `ci`

No public Airbnb API or dependency is introduced.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added modern JavaScript linting rules for equality, variables, arrow functions, object syntax, constants, templates, parameters, constructors, spreads, and radix validation.
  - Updated TypeScript configurations with dedicated checks for property access, parameter ordering, and array constructors.
  - Updated recommended profiles to avoid conflicting JavaScript analysis rules and apply consistent stylistic checks.

- **Bug Fixes**
  - Updated required-value validation to handle both `null` and `undefined` explicitly without changing expected behavior.

- **Tests**
  - Expanded coverage for rule enforcement, autofix stability, and configuration-profile consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->