### PR TITLE
docs: complete canonical executable examples

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,7 @@ jobs:
           runtime: node@24.20.0
           cache: true
       - run: pnpm --filter eslint-config-yarapa build
+      - run: pnpm exec tsc --noEmit -p examples/tsconfig.json
       - run: pnpm exec eslint --config examples/next/eslint.config.mjs examples/next
       - run: pnpm exec eslint --config examples/nest/eslint.config.mjs examples/nest
       - run: pnpm exec eslint --config examples/react/eslint.config.mjs examples/react

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,9 +72,9 @@ jobs:
           runtime: node@24.20.0
           cache: true
       - run: pnpm --filter eslint-config-yarapa build
-      - run: pnpm exec eslint --config examples/next/eslint.config.mjs examples/next/app/page.tsx
-      - run: pnpm exec eslint --config examples/nest/eslint.config.mjs examples/nest/src/example.service.ts
-      - run: pnpm exec eslint --config examples/react/eslint.config.mjs examples/react/src/example.tsx
+      - run: pnpm exec eslint --config examples/next/eslint.config.mjs examples/next
+      - run: pnpm exec eslint --config examples/nest/eslint.config.mjs examples/nest
+      - run: pnpm exec eslint --config examples/react/eslint.config.mjs examples/react
 
   consumer:
     name: consumer

--- a/README.md
+++ b/README.md
@@ -125,6 +125,8 @@ The repository contains executable examples under:
 
 Their repository-local `eslint.config.mjs` files load the built workspace artifact so CI can lint the examples before publication. Consumer projects should use the package imports shown in the quick starts above.
 
+Together the examples demonstrate value imports and type-only imports, typed module boundaries, async work and explicit error handling, an App Router-shaped Next.js page boundary, React component/custom-hook composition, and a NestJS service/repository boundary.
+
 The examples are intentionally dependency-light. Real framework package installation and config loading are verified separately through packed-consumer compatibility jobs.
 
 ## Troubleshooting

--- a/docs/superpowers/plans/2026-09-02-post-merge-issue-reconciliation.md
+++ b/docs/superpowers/plans/2026-09-02-post-merge-issue-reconciliation.md
@@ -1,0 +1,127 @@
+# Post-Merge Issue Reconciliation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Reconcile the v1-readiness issues against merged `main`, close only acceptance-complete issues with evidence, and finish the remaining repository-code gap in canonical examples without changing repository/admin or npm registry settings.
+
+**Architecture:** Treat merged PRs #37–#41 and current `main` as the source of implementation truth. Separate repository-code acceptance from GitHub/npm administrative acceptance; never simulate missing admin features in code. The only repository-code follow-up identified by reconciliation is #34, whose canonical examples need richer executable patterns while remaining dependency-light.
+
+**Tech Stack:** TypeScript, ESLint 10 Flat Config, pnpm, GitHub Actions, GitHub Issues.
+
+**Spec:** `docs/superpowers/plans/2026-09-02-complete-open-issues.md`
+
+## Global Constraints
+
+- Base all repository changes on `main@70e9108440675768038006bf7b3d22f527ff1ca5`.
+- Do not change GitHub repository/ruleset/security settings in this change set.
+- Do not change npm registry Trusted Publisher settings, publish packages, create tags, or create releases.
+- Do not restore Stryker/mutation testing; PR #38 is the later maintainer decision.
+- Close an issue only when its current acceptance criteria are satisfied by merged implementation/runtime evidence.
+- Keep framework examples dependency-light; do not add React, Next.js, or NestJS packages solely for documentation examples.
+
+---
+
+### Task 1: Reconcile and close acceptance-complete issues
+
+**Files:**
+- None.
+
+**Interfaces:**
+- Consumes: merged PRs #37, #38, #39, #40, #41; current `main`; current ruleset/repository metadata.
+- Produces: evidence comments and completed issue states for acceptance-complete issues.
+
+- [ ] **Step 1: Verify the issue remains open immediately before writing.**
+
+Use the GitHub issue API for each candidate issue.
+
+- [ ] **Step 2: Add an evidence comment.**
+
+Reference the merged PR(s), current `main` behavior, tests/workflow evidence, and any relevant runtime evidence. Do not claim admin acceptance for repository settings that were not verified.
+
+- [ ] **Step 3: Close the issue as completed.**
+
+Close only these candidates after the evidence check confirms no acceptance gap: #13, #14, #15, #20, #21, #22, #23, #25, #26, #27, #28, #29, #31, #32, #33, #35.
+
+- [ ] **Step 4: Leave blockers open and document their exact remaining acceptance gaps.**
+
+Keep #16, #17, #18, #19, #30, #34, and #36 open. Record: Release Please cannot create its PR because repository Actions PR creation is disabled (#16); GitHub-native security settings remain admin acceptance (#17); ruleset still requires implementation-specific checks and CodeRabbit (#18/#36); Discussions/org defaults remain absent (#19); mutation requirement is superseded by PR #38 while the issue text remains stale (#30); canonical examples remain too minimal (#34).
+
+### Task 2: Enrich canonical executable examples for #34
+
+**Files:**
+- Create: `examples/next/lib/query.ts`
+- Create: `examples/next/types.ts`
+- Modify: `examples/next/app/page.tsx`
+- Create: `examples/react/src/greeting.ts`
+- Create: `examples/react/src/types.ts`
+- Modify: `examples/react/src/example.tsx`
+- Create: `examples/nest/src/message.repository.ts`
+- Modify: `examples/nest/src/example.service.ts`
+
+**Interfaces:**
+- Consumes: existing example `eslint.config.mjs` files and `examples/tsconfig.json`.
+- Produces: dependency-light source examples showing value imports, type-only imports, TypeScript narrowing, async/error handling, Next App-Router-shaped input, React component/custom-hook composition, and Nest service/repository boundaries.
+
+- [ ] **Step 1: Add local type/value modules and update examples to consume them.**
+
+Next.js:
+- `types.ts` exports `SearchValue` and `PageInput` types.
+- `lib/query.ts` exports `readSingleQueryValue(value: SearchValue): string | undefined` and imports `SearchValue` with `import type`.
+- `app/page.tsx` imports the helper and `PageInput`, awaits `searchParams`, validates a required `name`, and returns a deterministic page string.
+
+React:
+- `types.ts` exports readonly `GreetingProps`.
+- `greeting.ts` exports `formatGreeting(name: string): string`.
+- `example.tsx` uses value + type-only imports, exposes `useGreeting(name: string): string`, and calls that hook at the top level of `Greeting`.
+
+NestJS:
+- `message.repository.ts` exports `MessageRepository`.
+- `example.service.ts` imports the repository type and keeps explicit async/error handling.
+
+- [ ] **Step 2: Verify examples with the same commands used by CI.**
+
+Run through GitHub Actions on the pull request:
+
+```sh
+pnpm --filter eslint-config-yarapa build
+pnpm exec eslint --config examples/next/eslint.config.mjs examples/next/app/page.tsx examples/next/lib/query.ts examples/next/types.ts
+pnpm exec eslint --config examples/nest/eslint.config.mjs examples/nest/src/example.service.ts examples/nest/src/message.repository.ts
+pnpm exec eslint --config examples/react/eslint.config.mjs examples/react/src/example.tsx examples/react/src/greeting.ts examples/react/src/types.ts
+```
+
+Expected: all commands pass with zero warnings/errors.
+
+- [ ] **Step 3: Update the CI example job to lint every canonical example source file.**
+
+Replace single-file commands with directory globs/paths that include the new helper/type files. Keep the built package as the config source.
+
+- [ ] **Step 4: Update README canonical-example wording only if needed.**
+
+State that the examples demonstrate imports/type-only imports, typed boundaries, async/error handling, and framework-shaped composition while real framework package loading remains covered by packed-consumer jobs.
+
+### Task 3: Verify and prepare the follow-up PR
+
+**Files:**
+- Modify only if review evidence requires it: files from Task 2.
+
+**Interfaces:**
+- Consumes: Task 2 branch head and GitHub Actions/CodeRabbit feedback.
+- Produces: one reviewable PR that closes #34 only when exact-head CI and review evidence pass.
+
+- [ ] **Step 1: Open a PR from `docs/complete-canonical-examples` to `main`.**
+
+Title: `docs: complete canonical executable examples`
+
+Body must state that it targets the remaining repository-code acceptance gap in #34 and does not alter admin/security/npm settings.
+
+- [ ] **Step 2: Wait for exact-head required checks and review.**
+
+Required evidence: `lint`, `test`, `check-types`, `build`, `consumer`, `windows-consumer`, `diagnostic-snapshot`, `ci`, and CodeRabbit under the current ruleset.
+
+- [ ] **Step 3: Address only valid review findings.**
+
+Do not weaken checks or add dependencies to satisfy review convenience.
+
+- [ ] **Step 4: Close #34 only after the PR is merged.**
+
+Until merge, leave #34 open and comment with the follow-up PR link/status.

--- a/docs/superpowers/plans/2026-09-02-post-merge-issue-reconciliation.md
+++ b/docs/superpowers/plans/2026-09-02-post-merge-issue-reconciliation.md
@@ -57,6 +57,8 @@ Keep #16, #17, #18, #19, #30, #34, and #36 open. Record: Release Please cannot c
 - Modify: `examples/react/src/example.tsx`
 - Create: `examples/nest/src/message.repository.ts`
 - Modify: `examples/nest/src/example.service.ts`
+- Modify: `.github/workflows/ci.yml`
+- Modify: `README.md`
 
 **Interfaces:**
 - Consumes: existing example `eslint.config.mjs` files and `examples/tsconfig.json`.
@@ -84,16 +86,17 @@ Run through GitHub Actions on the pull request:
 
 ```sh
 pnpm --filter eslint-config-yarapa build
-pnpm exec eslint --config examples/next/eslint.config.mjs examples/next/app/page.tsx examples/next/lib/query.ts examples/next/types.ts
-pnpm exec eslint --config examples/nest/eslint.config.mjs examples/nest/src/example.service.ts examples/nest/src/message.repository.ts
-pnpm exec eslint --config examples/react/eslint.config.mjs examples/react/src/example.tsx examples/react/src/greeting.ts examples/react/src/types.ts
+pnpm exec tsc --noEmit -p examples/tsconfig.json
+pnpm exec eslint --config examples/next/eslint.config.mjs examples/next
+pnpm exec eslint --config examples/nest/eslint.config.mjs examples/nest
+pnpm exec eslint --config examples/react/eslint.config.mjs examples/react
 ```
 
-Expected: all commands pass with zero warnings/errors.
+Expected: TypeScript type checking and all three ESLint directory checks pass with zero errors or warnings.
 
-- [ ] **Step 3: Update the CI example job to lint every canonical example source file.**
+- [ ] **Step 3: Update the CI example job to typecheck and lint every canonical example source file.**
 
-Replace single-file commands with directory globs/paths that include the new helper/type files. Keep the built package as the config source.
+Run the shared examples TypeScript project before linting each complete example directory. Keep the built package as the ESLint config source.
 
 - [ ] **Step 4: Update README canonical-example wording only if needed.**
 

--- a/examples/nest/src/example.service.ts
+++ b/examples/nest/src/example.service.ts
@@ -1,6 +1,4 @@
-export type MessageRepository = {
-  findMessage(id: string): Promise<string | undefined>;
-};
+import type { MessageRepository } from "./message.repository.js";
 
 /**
  * Small service boundary showing typed async work and explicit error handling.

--- a/examples/nest/src/message.repository.ts
+++ b/examples/nest/src/message.repository.ts
@@ -1,0 +1,6 @@
+/**
+ * Storage boundary used by the Nest service example.
+ */
+export type MessageRepository = {
+  findMessage(id: string): Promise<string | undefined>;
+};

--- a/examples/next/app/page.tsx
+++ b/examples/next/app/page.tsx
@@ -1,14 +1,16 @@
-import { readSingleQueryValue } from "../lib/query.js";
 import type { PageInput } from "../types.js";
+import { readSingleQueryValue } from "../lib/query.js";
 
 /**
- * Render a small App Router-shaped page without external example dependencies.
+ * Render an App Router-shaped page without external example dependencies.
  * @param input Page input.
- * @param input.searchParams Asynchronous search parameters supplied by the page boundary.
+ * @param input.searchParams Asynchronous search parameters from the page boundary.
  * @returns Rendered page text.
- * @throws {Error} When the required name query parameter is missing or ambiguous.
+ * @throws {Error} When the required name parameter is missing or ambiguous.
  */
-export default async function Page({ searchParams }: PageInput): Promise<string> {
+export default async function Page(
+  { searchParams }: PageInput,
+): Promise<string> {
   const query = await searchParams;
   const name = readSingleQueryValue(query.name);
 

--- a/examples/next/app/page.tsx
+++ b/examples/next/app/page.tsx
@@ -1,7 +1,20 @@
+import { readSingleQueryValue } from "../lib/query.js";
+import type { PageInput } from "../types.js";
+
 /**
- * Render a small Next.js page without external example dependencies.
+ * Render a small App Router-shaped page without external example dependencies.
+ * @param input Page input.
+ * @param input.searchParams Asynchronous search parameters supplied by the page boundary.
  * @returns Rendered page text.
+ * @throws {Error} When the required name query parameter is missing or ambiguous.
  */
-export default function Page(): string {
-  return "YARAPA";
+export default async function Page({ searchParams }: PageInput): Promise<string> {
+  const query = await searchParams;
+  const name = readSingleQueryValue(query.name);
+
+  if (name === undefined || name.trim().length === 0) {
+    throw new Error("A single non-empty name query parameter is required");
+  }
+
+  return `YARAPA — ${name}`;
 }

--- a/examples/next/app/page.tsx
+++ b/examples/next/app/page.tsx
@@ -1,10 +1,11 @@
 import type { PageInput } from "../types.js";
+
 import { readSingleQueryValue } from "../lib/query.js";
 
 /**
  * Render an App Router-shaped page without external example dependencies.
  * @param input Page input.
- * @param input.searchParams Asynchronous search parameters from the page boundary.
+ * @param input.searchParams Search parameters supplied to the page.
  * @returns Rendered page text.
  * @throws {Error} When the required name parameter is missing or ambiguous.
  */

--- a/examples/next/lib/query.ts
+++ b/examples/next/lib/query.ts
@@ -1,0 +1,14 @@
+import type { SearchValue } from "../types.js";
+
+/**
+ * Read one query value while rejecting ambiguous repeated values.
+ * @param value Search parameter value.
+ * @returns A single value when present and unambiguous.
+ */
+export function readSingleQueryValue(value: SearchValue): string | undefined {
+  if (Array.isArray(value)) {
+    return value.length === 1 ? value[0] : undefined;
+  }
+
+  return value;
+}

--- a/examples/next/lib/query.ts
+++ b/examples/next/lib/query.ts
@@ -6,9 +6,9 @@ import type { SearchValue } from "../types.js";
  * @returns A single value when present and unambiguous.
  */
 export function readSingleQueryValue(value: SearchValue): string | undefined {
-  if (Array.isArray(value)) {
-    return value.length === 1 ? value[0] : undefined;
+  if (typeof value === "string" || value === undefined) {
+    return value;
   }
 
-  return value;
+  return value.length === 1 ? value[0] : undefined;
 }

--- a/examples/next/types.ts
+++ b/examples/next/types.ts
@@ -1,0 +1,5 @@
+export type SearchValue = string | readonly string[] | undefined;
+
+export type PageInput = {
+  readonly searchParams: Promise<Readonly<Record<string, SearchValue>>>;
+};

--- a/examples/next/types.ts
+++ b/examples/next/types.ts
@@ -1,5 +1,5 @@
-export type SearchValue = string | readonly string[] | undefined;
-
 export type PageInput = {
   readonly searchParams: Promise<Readonly<Record<string, SearchValue>>>;
 };
+
+export type SearchValue = readonly string[] | string | undefined;

--- a/examples/react/src/example.tsx
+++ b/examples/react/src/example.tsx
@@ -1,14 +1,6 @@
-import { formatGreeting } from "./greeting.js";
 import type { GreetingProps } from "./types.js";
 
-/**
- * Compose greeting behavior behind a React custom-hook boundary.
- * @param name Name included in the greeting.
- * @returns Normalized greeting text.
- */
-export function useGreeting(name: string): string {
-  return formatGreeting(name);
-}
+import { formatGreeting } from "./greeting.js";
 
 /**
  * Render a typed React component without framework-specific global state.
@@ -18,4 +10,13 @@ export function useGreeting(name: string): string {
  */
 export function Greeting({ name }: GreetingProps): string {
   return useGreeting(name);
+}
+
+/**
+ * Compose greeting behavior behind a React custom-hook boundary.
+ * @param name Name included in the greeting.
+ * @returns Normalized greeting text.
+ */
+export function useGreeting(name: string): string {
+  return formatGreeting(name);
 }

--- a/examples/react/src/example.tsx
+++ b/examples/react/src/example.tsx
@@ -1,6 +1,14 @@
-type GreetingProps = {
-  readonly name: string;
-};
+import { formatGreeting } from "./greeting.js";
+import type { GreetingProps } from "./types.js";
+
+/**
+ * Compose greeting behavior behind a React custom-hook boundary.
+ * @param name Name included in the greeting.
+ * @returns Normalized greeting text.
+ */
+export function useGreeting(name: string): string {
+  return formatGreeting(name);
+}
 
 /**
  * Render a typed React component without framework-specific global state.
@@ -9,5 +17,5 @@ type GreetingProps = {
  * @returns Rendered greeting text.
  */
 export function Greeting({ name }: GreetingProps): string {
-  return `Hello, ${name}`;
+  return useGreeting(name);
 }

--- a/examples/react/src/greeting.ts
+++ b/examples/react/src/greeting.ts
@@ -1,0 +1,14 @@
+/**
+ * Format the greeting text rendered by the component example.
+ * @param name Name included in the greeting.
+ * @returns Normalized greeting text.
+ */
+export function formatGreeting(name: string): string {
+  const normalizedName = name.trim();
+
+  if (normalizedName.length === 0) {
+    return "Hello, guest";
+  }
+
+  return `Hello, ${normalizedName}`;
+}

--- a/examples/react/src/types.ts
+++ b/examples/react/src/types.ts
@@ -1,0 +1,3 @@
+export type GreetingProps = {
+  readonly name: string;
+};


### PR DESCRIPTION
## Goal

Complete the remaining repository-code acceptance gap in #34 with canonical examples that are useful to humans and AI agents and are continuously linted by the built YARAPA config.

## Changes

- expand the Next.js example with local value/type imports, an App Router-shaped async boundary, narrowing, and explicit error handling
- expand the React example with local value/type imports and component/custom-hook composition
- split the NestJS repository boundary into a typed imported module while preserving async/error handling
- lint the complete `examples/next`, `examples/nest`, and `examples/react` trees in CI
- document the concrete patterns demonstrated by the examples

## Constraints

- no framework dependency additions solely for documentation
- no dependency or lockfile changes
- no GitHub repository/ruleset/security setting changes
- no npm registry/publish/tag/release changes

Real framework package loading and supported-version behavior remain verified by the packed-consumer compatibility matrix added in #41.

Relates to #34.

Plan: `docs/superpowers/plans/2026-09-02-post-merge-issue-reconciliation.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated the Next.js example to read a single `name` query parameter and display a personalized greeting.
  * Added validation and error handling for missing or repeated query values.
  * Enhanced React and NestJS examples with reusable greeting and asynchronous message-handling patterns.

* **Documentation**
  * Expanded the examples overview to describe supported import, type-safety, error-handling, and framework-specific patterns.

* **Chores**
  * Improved continuous integration by type-checking examples and linting complete Next.js, React, and NestJS example directories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->