### PR TITLE
ci: use GitHub App token for Release Please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -6,15 +6,26 @@ on:
       - main
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   release-please:
     name: release-please
     runs-on: ubuntu-latest
     steps:
-      - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
+          client-id: ${{ vars.RELEASE_PLEASE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-issues: write
+          permission-pull-requests: write
+
+      - name: Release Please
+        uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5
+        with:
+          token: ${{ steps.app-token.outputs.token }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json


### PR DESCRIPTION
## Goal

Use the same conventional Release Please authentication pattern used by established OSS repositories: `actions/create-github-app-token` generates a short-lived GitHub App installation token and `googleapis/release-please-action` consumes it.

## Changes

- use official `actions/create-github-app-token` v3.2.0 pinned to commit SHA
- use the current `client-id` input (the action deprecates `app-id`)
- grant the installation token only the permissions Release Please requires: contents, issues, and pull requests write
- pass that short-lived installation token to the existing pinned Release Please v5 action
- reduce the workflow's built-in `GITHUB_TOKEN` permission to `contents: read`

## Required repository configuration

This follows the official action contract and requires:
- repository/org variable `RELEASE_PLEASE_APP_CLIENT_ID`
- repository/org secret `RELEASE_PLEASE_APP_PRIVATE_KEY`
- the GitHub App installed on this repository with Contents, Issues, and Pull requests write permissions

No PAT, custom release bot code, wrapper script, fallback token logic, or YARAPA-specific release state is introduced.

Relates to #16.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release automation to use more narrowly scoped access permissions.
  * Preserved the required capabilities for creating and updating release-related items.
  * Improved the security of the release process by separating routine repository access from publishing actions.
  * No changes were made to the application’s features or end-user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->