### PR TITLE
feat(community): route support to Discussions

### DIFF
--- a/.changeset/community-discussions.md
+++ b/.changeset/community-discussions.md
@@ -1,0 +1,4 @@
+---
+---
+
+Route contributor questions and exploratory ideas through GitHub Discussions.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Questions and usage help
+    url: https://github.com/useyarapa/eslint-config-yarapa/discussions/categories/q-a
+    about: Ask configuration and usage questions in GitHub Discussions.
+  - name: Ideas and design discussion
+    url: https://github.com/useyarapa/eslint-config-yarapa/discussions/categories/ideas
+    about: Discuss exploratory ideas before turning them into concrete feature requests.

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,30 @@
+name: Feature request
+description: Propose a concrete change to eslint-config-yarapa.
+title: "feat: "
+labels: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form for actionable feature requests. For usage questions or exploratory ideas, use GitHub Discussions instead.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What concrete limitation or use case should be addressed?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed change
+      description: Describe the smallest change that would address the problem.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Optional alternatives, workarounds, or upstream conventions you considered.
+    validations:
+      required: false


### PR DESCRIPTION
Closes #19

- enable GitHub Discussions for the repository
- add standard Q&A and Ideas contact links from Issues
- add a concrete Feature request form alongside the existing Bug report
- keep blank issues enabled rather than imposing a custom taxonomy
- use the built-in GitHub Discussions categories (`Q&A`, `Ideas`, `Announcements`)
- do not create an organization `.github` repository because GitHub shared community-health inheritance requires that repository to be public, while this organization intentionally does not publish internal/shared configuration solely for inheritance

This PR contains only repo-specific contributor routing; no bespoke governance framework is introduced.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added guidance directing contributor questions, usage help, and exploratory ideas to GitHub Discussions.
  - Added a structured feature-request template with fields for the problem, proposed change, and alternatives.
  - Enabled blank issue submission for cases not covered by the available templates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->